### PR TITLE
handle grffile as a legacy package in template.tex

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: komaletter
 Title: Simple yet Flexible Letters via the 'KOMA-Script LaTeX Bundle'
-Version: 0.3.1
+Version: 0.3.1.9000
 Authors@R: c(
     person("Robert", "Nuske", role=c("aut", "cre"), email="robert.nuske@mailbox.org",
            comment=c(ORCID="0000-0001-9773-2061")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# komaletter (development version)
+
+  * modify default template to take into account the grffile tex package now a legacy package. Same fix as in pandoc and rmarkdown. 
+
 # komaletter 0.3.1
   * added a section to the intro vignette about non-English letters
   * slightly darker header and foldmarks in default style (maintainersDelight.lco)

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -124,6 +124,10 @@ $if(tables)$
 $endif$
 $if(graphics)$
 \usepackage{graphicx}
+% grffile has become a legacy package: https://ctan.org/pkg/grffile
+\IfFileExists{grffile.sty}{%
+\usepackage{grffile}
+}{}
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -123,7 +123,11 @@ $if(tables)$
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
 $endif$
 $if(graphics)$
-\usepackage{graphicx,grffile}
+\usepackage{graphicx}
+% grffile has become a legacy package: https://ctan.org/pkg/grffile
+\IfFileExists{grffile.sty}{%
+\usepackage{grffile}
+}{}
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -124,10 +124,6 @@ $if(tables)$
 $endif$
 $if(graphics)$
 \usepackage{graphicx}
-% grffile has become a legacy package: https://ctan.org/pkg/grffile
-\IfFileExists{grffile.sty}{%
-\usepackage{grffile}
-}{}
 \makeatletter
 \def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
 \def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -189,7 +189,11 @@ $if(dir)$
 \fi
 $endif$
 
-\usepackage{graphicx,grffile}
+\usepackage{graphicx}
+% grffile has become a legacy package: https://ctan.org/pkg/grffile
+\IfFileExists{grffile.sty}{%
+\usepackage{grffile}
+}{}
 % set default figure placement to htbp
 \makeatletter
 \def\fps@figure{htbp}


### PR DESCRIPTION
This will close #7 and relates to https://github.com/rstudio/rmarkdown/issues/1691

There was a change with `grffile` tex package that is now a legacy package and no more on Texlive. 
The template calls explicitly this 📦 and creates some errors. 

This PR just uses the same fix as in Rmarkdown. 

I should help fix it 