### PR TITLE
Feature request: bank details

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -38,6 +38,8 @@ navbar:
         href: articles/pkgdown_letter_example3.html
       - text: Example 4
         href: articles/pkgdown_letter_example4.html
+      - text: Example 5
+        href: articles/pkgdown_letter_example5.html
 
 template:
   params:

--- a/inst/rmarkdown/templates/pdf/resources/maintainersDelight.lco
+++ b/inst/rmarkdown/templates/pdf/resources/maintainersDelight.lco
@@ -6,7 +6,7 @@
 % Options  --------------------------------------------------------------------
 \KOMAoptions{%
   parskip=half,              % half line skip between paragraphs
-  firstfoot=false,           % no footer
+  firstfoot=true,           % no footer
   enlargefirstpage,          % longer first page works well with no footer
   refline=narrow,            % adjust refline with text body
   backaddress=plain          % do not underline backaddress in address window
@@ -65,6 +65,8 @@
 % Signature
 \let\raggedsignature\raggedright
 
+% Footer
+\@setplength{firstfoothpos}{30mm}
 
 % Custom Letter Head ----------------------------------------------------------
 \setkomavar{firsthead}{%
@@ -79,4 +81,14 @@
       \ifkomavarempty{fromurl}{}{\usekomavar{fromurl}~\Mundus\\}%
     }
   }
+}
+
+% Custom Footer ----------------------------------------------------------
+% Taken from https://gitlab.com/yuvallanger/worg/-/blob/b0ac61fb701135a77c8b5fad13c788010bbb2acb/exporters/koma-letter-export.org
+% Banking information in the footer
+\setkomavar{firstfoot}{%
+  \footnotesize
+  \parbox[b]{\linewidth}{%
+    \centering\def\\{ \textbullet{} }\ifkomavarempty{frombank}{}{{\def\\{,\nobreakspace\@ogobble}\usekomavar{frombank}}\\}%
+  }%
 }

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -244,6 +244,7 @@ $if(return-url)$
 \setkomavar{fromurl}{$return-url$}
 $endif$
 
+
 $if(date)$\setkomavar{date}{$date$}$endif$
 $if(yourref)$\setkomavar{yourref}{$yourref$}$endif$
 $if(yourmail)$\setkomavar{yourmail}{$yourmail$}$endif$
@@ -253,6 +254,12 @@ $if(invoice)$\setkomavar{invoice}{$invoice$}$endif$
 $if(place)$\setkomavar{place}{$place$}$endif$
 $if(subject)$\setkomavar{subject}{$subject$}$endif$
 $if(author)$\setkomavar{fromname}{$author$}$endif$
+
+
+$if(bank)$
+\setkomavar{frombank}{$for(bank)$$bank$$sep$\\$endfor$}
+$endif$
+
 $if(return-address)$
 \setkomavar{fromaddress}{$for(return-address)$$return-address$$sep$\\$endfor$}
 $endif$

--- a/vignettes/letter_example5.Rmd
+++ b/vignettes/letter_example5.Rmd
@@ -1,0 +1,79 @@
+---
+author: Winkel van Sinkel
+address:
+- Fancy Work
+- Vleutensebaan 435
+- 7009 ZZ Haarlem
+- Netherlands
+- NL1093se44
+subject: FACTUUR
+customer: '060101'
+invoice: '000003'
+lang: nl
+bank:
+- 'KVK: 12345678'
+- 'Btw-id: NL123456789B01'
+- 'IBAN: NL99ABCD0123456789'
+- 'BIC: AAAABBCCDD'
+params:
+  bank_num: 'IBAN: NL99ABCD0123456789'
+  invoice_num: '000001'
+  customer_num: '060101'
+return-address:
+- Modelstraat 12
+- 3017 KH Amsterdam
+- Netherlands
+return-email: somebody@gmail.com
+return-phone: '03012345'
+return-url: https
+date: '`r format(Sys.Date(), "%d %B, %Y")`'
+
+output: komaletter::komaletter
+
+vignette: >
+  %\VignetteIndexEntry{komaletter example letter 5}
+  %\VignetteKeywords{komaletter,vignette}
+  %\VignettePackage{komaletter}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(echo = FALSE)
+```
+
+
+**Geleverd op `r format(as.Date("2021-09-08"), "%d %B, %Y")`:**
+
+
+```{r bill}
+# initiate bill
+bill <- bookkeeper::add_bill_entry(
+  c(
+    "Tekstproductie (80 uur à € 70)",
+    "Ontwerp (vaste prijs)",
+    "10 foto’s à € 150",
+    "Vormgeving (30 uur à € 60)",
+    "1 kg Suiker"
+  ),
+  c(21, 21, 21, 21, 9),
+  "€",
+  c(5600, 1250, 1500, 1800, 3),
+  .save = FALSE
+)
+bill <- bookkeeper::make_bill(lang = "nl", .save = FALSE, .bill = bill)
+```
+
+
+```{r kbl}
+# kable output bill
+bookkeeper::kable_bill(bill)
+```
+
+
+\vspace{3em}
+
+
+Betaling graag binnen 14 dagen na factuurdatum op `r params$bank_num` onder vermelding van het factuurnummer: `r params$invoice_num` en het klantnummer: `r params$customer_num`.
+

--- a/vignettes/letter_example5.Rmd
+++ b/vignettes/letter_example5.Rmd
@@ -5,7 +5,6 @@ address:
 - Vleutensebaan 435
 - 7009 ZZ Haarlem
 - Netherlands
-- NL1093se44
 subject: FACTUUR
 customer: '060101'
 invoice: '000003'
@@ -28,7 +27,9 @@ return-phone: '03012345'
 return-url: https
 date: '`r format(Sys.Date(), "%d %B, %Y")`'
 
-output: komaletter::komaletter
+output: 
+  komaletter::komaletter:
+    extra_dependencies: ["tabu", "booktabs"]
 
 vignette: >
   %\VignetteIndexEntry{komaletter example letter 5}
@@ -47,8 +48,10 @@ knitr::opts_chunk$set(echo = FALSE)
 **Geleverd op `r format(as.Date("2021-09-08"), "%d %B, %Y")`:**
 
 
-```{r bill}
-# initiate bill
+```{r, eval=FALSE} 
+# make a bill with bookkeeper
+# install.packages("devtools")
+# devtools::install_github("MartinSchobben/bookkeeper")
 bill <- bookkeeper::add_bill_entry(
   c(
     "Tekstproductie (80 uur à € 70)",
@@ -56,20 +59,39 @@ bill <- bookkeeper::add_bill_entry(
     "10 foto’s à € 150",
     "Vormgeving (30 uur à € 60)",
     "1 kg Suiker"
-  ),
+    ),
   c(21, 21, 21, 21, 9),
   "€",
   c(5600, 1250, 1500, 1800, 3),
+  "service",
   .save = FALSE
 )
+# make bill
 bill <- bookkeeper::make_bill(lang = "nl", .save = FALSE, .bill = bill)
-```
-
-
-```{r kbl}
 # kable output bill
 bookkeeper::kable_bill(bill)
 ```
+
+\begingroup\fontsize{10}{12}\selectfont
+
+\begin{tabu} to \linewidth {>{\raggedright\arraybackslash}p{30em}>{\centering\arraybackslash}p{5em}>{\centering\arraybackslash}p{2em}>{\raggedleft\arraybackslash}p{4em}}
+\toprule
+Tekstproductie (80 uur à € 70) & Btw 21 \% & € & 5600.00\\
+Ontwerp (vaste prijs) & Btw 21 \% & € & 1250.00\\
+10 foto’s à € 150 & Btw 21 \% & € & 1500.00\\
+Vormgeving (30 uur à € 60) & Btw 21 \% & € & 1800.00\\
+1 kg Suiker & Btw 9 \% & € & 3.00\\
+\midrule
+\addlinespace
+Subtotaal &  & € & 10153.00\\
+\hspace{1em}Btw 21 \% &  & € & 2131.50\\
+\hspace{1em}Btw 9 \% &  & € & 0.27\\
+\midrule
+\textbf{Totaal} & \textbf{} & \textbf{€} & \textbf{12284.77}\\
+\midrule
+\bottomrule
+\end{tabu}
+\endgroup{}
 
 
 \vspace{3em}

--- a/vignettes/pkgdown_letter_example5.Rmd
+++ b/vignettes/pkgdown_letter_example5.Rmd
@@ -14,7 +14,9 @@ a ```-chunk which is hard to get around when included in a chunk. -->
 
 ````markdown
 ```{r cars, results='asis', echo=FALSE}
-cat(paste(readLines('letter_example5.Rmd')[!grepl('ignette', x=readLines('letter_example5.Rmd'))], collapse ='\n'))
+md <- readLines('letter_example5.Rmd')[!grepl('\\\\|vignette', x=readLines('letter_example5.Rmd'))]
+md <- sub('r, eval=FALSE', 'r', x = md)
+cat(paste(md, collapse ='\n'))
 ```
 ````
 

--- a/vignettes/pkgdown_letter_example5.Rmd
+++ b/vignettes/pkgdown_letter_example5.Rmd
@@ -1,0 +1,32 @@
+---
+title: "Example 5"
+description: "Invoice"
+output: html_document
+---
+
+Generate an invoice with bank details.
+
+<br>
+
+### RMarkdown of Letter
+<!-- This weird setup of the chunk is necessary because the letter contains 
+a ```-chunk which is hard to get around when included in a chunk. -->
+
+````markdown
+```{r cars, results='asis', echo=FALSE}
+cat(paste(readLines('letter_example5.Rmd')[!grepl('ignette', x=readLines('letter_example5.Rmd'))], collapse ='\n'))
+```
+````
+
+<br>
+
+### Resulting PDF Letter
+
+PDF rendered via `rmarkdown::render()` or the RStudio Knit button from RMarkdown document above.
+
+```{r render-pdf, include=FALSE}
+rmarkdown::render("letter_example5.Rmd", output_file="pkgdown_ex5.pdf", output_dir='.')
+pdftools::pdf_convert(pdf='pkgdown_ex5.pdf', dpi=150, format="jpeg", pages=1, filenames="pkgdown_ex5.jpg")
+```
+
+<img src="pkgdown_ex5.jpg" alt="Here should be an image of the PDF letter" width="100%" style="border: 1px solid #ccc;">


### PR DESCRIPTION
Hi Robert - I was wondering whether it would be possible to have an option to include bank details as a footer to the letter. I am working on a project where I want to generate invoices with komaletter. Besides changes to the resource files, I included an example (example 5) that shows creating an invoice. I can change the content of the example to just an markdown table, so that you don't have to rely on my work-in-progress remote. Or I can completely delete it. For now, it is just to demonstrate my use case.